### PR TITLE
Fix CommonJS exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "module": "index.mjs",
   "exports": {
     ".": {
-      "require": "./build/index.cjs.js",
+      "require": "./dist/index.cjs.js",
       "import": "./index.mjs"
     },
     "./*": {


### PR DESCRIPTION
> Fixes #6.

The `package.json/exports/./require` should point to `/dist/` instead of `/build/`.